### PR TITLE
Refacto - removed unnecessary edit route in consultations

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get "/seeds", to: "pages#seeds" # Seeds
 
 
-  resources :consultations, only: [:index, :show, :new, :create, :edit, :update] do
+  resources :consultations, only: [:index, :show, :new, :create, :update] do
     resources :notes, only: [:new]
     resources :treatments, only: [:new, :create, :edit, :update]
   end


### PR DESCRIPTION
- Because the #edit consultation form (to change the consultation date) is nested on the consultation show (thanks @Alfred-gn !)
- #edit method was already removed from consultation controller in another branch