### PR TITLE
Modif consultation calendar

### DIFF
--- a/app/assets/stylesheets/consultation/_calendar.scss
+++ b/app/assets/stylesheets/consultation/_calendar.scss
@@ -1,5 +1,7 @@
 .calendar-header {
   box-shadow: inset 2px -7px 11px rgba(80, 92, 51, 0.17);
+  width: 100%;
+  height: 100%;
 }
 
 .calendar-action-date {

--- a/app/assets/stylesheets/consultation/_calendar.scss
+++ b/app/assets/stylesheets/consultation/_calendar.scss
@@ -31,6 +31,10 @@
   font-weight: lighter;
 }
 
+.date-info {
+  text-align: center;
+}
+
 #calendar-day {
   margin: 8px 0px 0px 0px;
   padding: 0;
@@ -41,7 +45,7 @@
 
 #calendar-date {
   margin: 0;
-  padding: 0;
+  padding-right: 4px;
   color: white;
   font-size: 60px;
   font-weight: bold;
@@ -50,7 +54,7 @@
 
 #calendar-month {
   margin: 0;
-  padding: 0;
+  padding-right: 4px;
   font-size: 20px;
   color: #545454;
 }
@@ -90,7 +94,7 @@
 .toastui-calendar-detail-container .toastui-calendar-content {
   padding: 4px 0px;
 }
-  
+
 // Treatments in pop-up details
 
 .toastui-calendar-detail-item-indent {

--- a/app/assets/stylesheets/consultation/_calendar.scss
+++ b/app/assets/stylesheets/consultation/_calendar.scss
@@ -59,6 +59,11 @@
   color: #545454;
 }
 
+.add-consultation img {
+  height: 32px;
+  margin: 0 0 4px 4px;
+}
+
 
 .toastui-calendar-day-view-day-names {
   display: none;

--- a/app/javascript/controllers/calendar_controller.js
+++ b/app/javascript/controllers/calendar_controller.js
@@ -212,7 +212,7 @@ export default class extends Controller {
   getAvatar(target) {
     this.img = document.createElement("img");
     this.img.src = `${target.getAttribute ('src')}`;
-    this.img.setAttribute("style", "height:72px; padding-right: 12px; padding-left: 12px;");
+    this.img.setAttribute("style", "height:48px; padding-right: 12px; padding-left: 12px;");
     return this.img
   }
 

--- a/app/javascript/controllers/calendar_controller.js
+++ b/app/javascript/controllers/calendar_controller.js
@@ -78,8 +78,8 @@ export default class extends Controller {
       },
       week: {
         daynames: ['Di', 'Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa'],
-        hourStart: 7,
-        hourEnd: 19,
+        hourStart: 5,
+        hourEnd: 22,
         taskView: false,
         showNowIndicator: true,
         eventView: ['time'],

--- a/app/javascript/controllers/calendar_controller.js
+++ b/app/javascript/controllers/calendar_controller.js
@@ -212,7 +212,7 @@ export default class extends Controller {
   getAvatar(target) {
     this.img = document.createElement("img");
     this.img.src = `${target.getAttribute ('src')}`;
-    this.img.setAttribute("style", "height:48px; padding-right: 12px; padding-left: 12px;");
+    this.img.setAttribute("style", "height:72px; padding-right: 12px; padding-left: 12px;");
     return this.img
   }
 

--- a/app/views/consultations/_index_with_tui_calendar.html.erb
+++ b/app/views/consultations/_index_with_tui_calendar.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       </div>
     </div>
-    <div  id="calendar" data-calendar-target="myCalendar" style="height: 1000px;">
+    <div  id="calendar" data-calendar-target="myCalendar" style="height: 1400px;">
     </div>
   </div>
 </div>

--- a/app/views/consultations/_index_with_tui_calendar.html.erb
+++ b/app/views/consultations/_index_with_tui_calendar.html.erb
@@ -10,10 +10,10 @@
         <div class="calendar-previous-day">
           <button class="calendar-next-previous-btn" data-action="click->calendar#previous"><</button>
         </div>
-        <div>
-          <div class="text-center"><p id="calendar-day"></p></div>
-          <div class="text-center"><p id="calendar-date"></p></div>
-          <div class="text-center"><p id="calendar-month"></p></div>
+        <div class="date-info">
+          <div><p id="calendar-day"></p></div>
+          <div><p id="calendar-date"></p></div>
+          <div><p id="calendar-month"></p></div>
         </div>
         <div class="calendar-next-day">
           <button class="calendar-next-previous-btn" data-action="click->calendar#next">></button>

--- a/app/views/consultations/_index_with_tui_calendar.html.erb
+++ b/app/views/consultations/_index_with_tui_calendar.html.erb
@@ -19,6 +19,11 @@
           <button class="calendar-next-previous-btn" data-action="click->calendar#next">></button>
         </div>
       </div>
+      <div class="add-consultation">
+        <%= link_to new_consultation_path do %>
+          <%= image_tag "icones/add-btn.svg" %>
+        <% end %>
+      </div>
     </div>
     <div  id="calendar" data-calendar-target="myCalendar" style="height: 1000px;">
     </div>


### PR DESCRIPTION
- display calendar from 5h to 22h and adjust front-end according

- add "+" btn to add a consultation in calendar 
<img width="216" alt="image" src="https://user-images.githubusercontent.com/104198121/212703323-f5362357-37eb-4db3-9576-579e7aa79b1c.png">

- add width and height to 100% for header-calendar in order to try to remove the bug on Iphone.
