### PR TITLE
Add first name and last name to user registration

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -22,7 +22,7 @@
 // SESSION NEW FORM
 
 .session_container_imag_title {
-  padding: 0px 0px 40px 0px;
+  padding: 0px 0px 20px 0px;
   background-color: white;
   display: flex;
   align-items: center;
@@ -59,9 +59,9 @@
   }
 }
 
-.formulaire {
-  padding: 20px 0px 40px 0px;
-}
+// .formulaire {
+//   padding: 20px 0px 40px 0px;
+// }
 
 // NOUVELLE CONSULTATION FORM
 .new_consultation {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -95,7 +95,7 @@
   background-color: white;
 }
 
-#user_email, #user_password, #user_first_name, #user_password_confirmation, #patient_first_name, #patient_last_name, #patient_address, #patient_email, #patient_tel_number, #patient_ss_number, #patient_referring_doctor, #patient_emergency_contact_name, #patient_emergency_contact_tel, #patient_height, #patient_weight, #consultation_patient_id, #consultation_start_date, #consultation_user_id {
+#user_email, #user_password, #user_first_name, #user_last_name, #user_password_confirmation, #patient_first_name, #patient_last_name, #patient_address, #patient_email, #patient_tel_number, #patient_ss_number, #patient_referring_doctor, #patient_emergency_contact_name, #patient_emergency_contact_tel, #patient_height, #patient_weight, #consultation_patient_id, #consultation_start_date, #consultation_user_id {
   background-color: white !important;
   border-radius: 75px !important;
   border: 1px solid $grey;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,7 @@ class User < ApplicationRecord
   has_many :memberships
   has_many :teams_as_creator, foreign_key: :creator_id, class_name: "team"
 
-  # validates :first_name, presence: true
-  # validates :last_name, presence: true
-  # validates :tel_number, presence: true
-  validates :email, presence: true, format: { with: /\A.*@.*\.com\z/ }
+  validates :first_name, :last_name, :email, presence: true
 
 
   def display_full_name

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,6 +10,18 @@
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
     <% end %>
 
+    <%= f.input :first_name,
+                placeholder: 'prénom',
+                required: true,
+                autofocus: true,
+                :label => false,
+                input_html: { autocomplete: "Prénom :" }%>
+    <%= f.input :last_name,
+                placeholder: 'Nom de famille',
+                required: true,
+                autofocus: true,
+                :label => false,
+                input_html: { autocomplete: "Nom de famille :" }%>
     <%= f.input :password,
                 hint: "leave it blank if you don't want to change it",
                 required: false,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,6 +14,18 @@
                   autofocus: true,
                   :label => false,
                   input_html: { autocomplete: "Email" }%>
+      <%= f.input :first_name,
+                  placeholder: 'prénom',
+                  required: true,
+                  autofocus: true,
+                  :label => false,
+                  input_html: { autocomplete: "Prénom :" }%>
+      <%= f.input :last_name,
+                  placeholder: 'Nom de famille',
+                  required: true,
+                  autofocus: true,
+                  :label => false,
+                  input_html: { autocomplete: "Nom de famille :" }%>
       <%= f.input :password,
                   required: true,
                   placeholder: 'Mot de passe (6 caractères)',

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   <body>
     <%= render "shared/flashes" %>
     <%= yield %>
+    <!-- do not display navbar on home page, on sign_up page or on registration page -->
     <%= render "shared/navbar_dahlia" unless current_page?('/') || controller.controller_name == 'sessions' || controller.controller_name == 'registrations' %>
 
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   <body>
     <%= render "shared/flashes" %>
     <%= yield %>
-    <%= render "shared/navbar_dahlia" unless current_page?('/') unless current_page?('/users/sign_in') unless current_page?('/users/sign_up') %>
+    <%= render "shared/navbar_dahlia" unless current_page?('/') || controller.controller_name == 'sessions' || controller.controller_name == 'registrations' %>
 
   </body>
 </html>

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -1,0 +1,145 @@
+fr:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: Date d'envoi de la confirmation
+        confirmation_token: Clé de confirmation du mot de passe
+        confirmed_at: Date de confirmation
+        created_at: Date d'enregistrement
+        current_password: Mot de passe actuel
+        current_sign_in_at: Date de la connexion actuelle
+        current_sign_in_ip: IP de la connexion actuelle
+        email: Email
+        encrypted_password: Mot de passe chiffré
+        failed_attempts: Tentatives échouées
+        last_sign_in_at: Date de la dernière connexion
+        last_sign_in_ip: IP de la dernière connexion
+        locked_at: Verrouillé à
+        password: Mot de passe
+        password_confirmation: Confirmation du mot de passe
+        remember_created_at: Mémorisé à
+        remember_me: Se souvenir de moi ?
+        reset_password_sent_at: Clé de réinitialisation créée à
+        reset_password_token: Clé de réinitialisation du mot de passe
+        sign_in_count: Nombre des connexions
+        unconfirmed_email: Email non confirmé
+        unlock_token: Clé de déverrouillage
+        updated_at: Date de mise à jour
+    models:
+      user: Utilisateur
+  devise:
+    confirmations:
+      confirmed: Votre compte a bien été confirmé.
+      new:
+        resend_confirmation_instructions: Renvoyer les instructions de confirmation
+      send_instructions: Vous allez recevoir sous quelques minutes un email comportant des instructions pour confirmer votre compte.
+      send_paranoid_instructions: Si votre email existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour confirmer votre compte.
+    failure:
+      already_authenticated: Vous êtes déjà connecté(e).
+      inactive: Votre compte n’est pas encore activé.
+      invalid: "%{authentication_keys} ou mot de passe incorrect."
+      last_attempt: Il vous reste une chance avant que votre compte soit bloqué.
+      locked: Votre compte est verrouillé.
+      not_found_in_database: "%{authentication_keys} ou mot de passe incorrect."
+      timeout: Votre session est expirée, veuillez vous reconnecter pour continuer.
+      unauthenticated: Vous devez vous connecter ou vous enregistrer pour continuer.
+      unconfirmed: Vous devez confirmer votre compte par email.
+    mailer:
+      confirmation_instructions:
+        action: Confirmer mon email
+        greeting: Bienvenue %{recipient} !
+        instruction: 'Vous pouvez confirmer votre email grâce au lien ci-dessous :'
+        subject: Instructions de confirmation
+      email_changed:
+        greeting: Bonjour %{recipient} !
+        message: Nous vous contactons pour vous informer que votre email a été changé en %{email}.
+        message_unconfirmed: Nous vous contactons pour vous informer que votre email est en train d'être changé par %{email}.
+        subject: Email modifié
+      password_change:
+        greeting: Bonjour %{recipient} !
+        message: Nous vous contactons pour vous notifier que votre mot de passe a été modifié.
+        subject: Mot de passe modifié
+      reset_password_instructions:
+        action: Changer mon mot de passe
+        greeting: Bonjour %{recipient} !
+        instruction: 'Quelqu''un a demandé un lien pour changer votre mot de passe, le voici :'
+        instruction_2: Si vous n'avez pas émis cette demande, merci d'ignorer cet email.
+        instruction_3: Votre mot de passe ne changera pas tant que vous n'aurez pas cliqué sur ce lien et renseigné un nouveau mot de passe.
+        subject: Instructions pour changer le mot de passe
+      unlock_instructions:
+        action: Débloquer mon compte
+        greeting: Bonjour %{recipient} !
+        instruction: 'Suivez ce lien pour débloquer votre compte :'
+        message: Votre compte a été bloqué suite à un nombre d'essais de connexions manquées trop important.
+        subject: Instructions pour déverrouiller le compte
+    omniauth_callbacks:
+      failure: 'Nous ne pouvons pas vous authentifier depuis %{kind} pour la raison suivante : ''%{reason}''.'
+      success: Autorisé par votre compte %{kind}.
+    passwords:
+      edit:
+        change_my_password: Changer mon mot de passe
+        change_your_password: Changer votre mot de passe
+        confirm_new_password: Confirmez votre nouveau mot de passe
+        new_password: Nouveau mot de passe
+      new:
+        forgot_your_password: Mot de passe oublié ?
+        send_me_reset_password_instructions: Envoyez-moi des instructions pour réinitialiser mon mot de passe
+      no_token: Vous ne pouvez pas accéder à cette page si vous n’y accédez pas depuis un email de réinitialisation de mot de passe. Si vous venez en effet d’un tel email, vérifiez que vous avez copié l’adresse URL en entier.
+      send_instructions: Vous allez recevoir sous quelques minutes un email vous indiquant comment réinitialiser votre mot de passe.
+      send_paranoid_instructions: Si votre email existe dans notre base de données, vous recevrez un lien vous permettant de récupérer votre mot de passe.
+      updated: Votre mot de passe a bien été modifié. Vous êtes maintenant connecté(e).
+      updated_not_active: Votre mot de passe a bien été modifié.
+    registrations:
+      destroyed: Au revoir ! Votre compte a bien été supprimé. Nous espérons vous revoir bientôt.
+      edit:
+        are_you_sure: Êtes-vous sûr ?
+        cancel_my_account: Supprimer mon compte
+        currently_waiting_confirmation_for_email: 'Confirmation en attente pour: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: laissez ce champ vide pour le laisser inchangé
+        title: Éditer %{resource}
+        unhappy: Pas content ?
+        update: Modifier
+        we_need_your_current_password_to_confirm_your_changes: nous avons besoin de votre mot de passe actuel pour valider ces modifications
+      new:
+        sign_up: Inscription
+      signed_up: Bienvenue ! Vous vous êtes bien enregistré(e).
+      signed_up_but_inactive: Vous vous êtes bien enregistré(e). Cependant, nous n’avons pas pu vous connecter car votre compte n’a pas encore été activé.
+      signed_up_but_locked: Vous vous êtes bien enregistré(e). Cependant, nous n’avons pas pu vous connecter car votre compte est verrouillé.
+      signed_up_but_unconfirmed: Un message avec un lien de confirmation vous a été envoyé par mail. Veuillez suivre ce lien pour activer votre compte.
+      update_needs_confirmation: Vous avez bien modifié votre compte, mais nous devons vérifier votre nouvelle adresse email. Veuillez consulter vos emails et cliquer sur le lien de confirmation pour confirmer votre nouvelle adresse.
+      updated: Votre compte a bien été modifié.
+      updated_but_not_signed_in: Votre compte a été mis à jour avec succès. Vous devez vous reconnecter car votre mot de passe a été modifié.
+    sessions:
+      already_signed_out: Déconnecté(e).
+      new:
+        sign_in: Connexion
+      signed_in: Connecté(e).
+      signed_out: Déconnecté(e).
+    shared:
+      links:
+        back: Retour
+        didn_t_receive_confirmation_instructions: Vous n'avez pas reçu l'email de confirmation ?
+        didn_t_receive_unlock_instructions: Vous n'avez pas reçu l'email de déblocage ?
+        forgot_your_password: Mot de passe oublié ?
+        sign_in: Connexion
+        sign_in_with_provider: Connexion avec %{provider}
+        sign_up: Inscription
+      minimum_password_length:
+        one: "(%{count} caractère au moins)"
+        other: "(%{count} caractères au moins)"
+    unlocks:
+      new:
+        resend_unlock_instructions: Renvoyer les instructions de déblocage
+      send_instructions: Vous allez recevoir sous quelques minutes un email comportant des instructions pour déverrouiller votre compte.
+      send_paranoid_instructions: Si votre email existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour déverrouiller votre compte.
+      unlocked: Votre compte a bien été déverrouillé. Veuillez vous connecter.
+  errors:
+    messages:
+      already_confirmed: a déjà été confirmé(e)
+      confirmation_period_expired: doit être confirmé(e) en %{period}, veuillez en demander un(e) autre
+      expired: est expiré, veuillez en demander un autre
+      not_found: n’a pas été trouvé(e)
+      not_locked: n’était pas verrouillé(e)
+      not_saved:
+        one: 'une erreur a empêché ce (cet ou cette) %{resource} d’être enregistré(e) :'
+        other: "%{count} erreurs ont empêché ce (cet ou cette) %{resource} d’être enregistré(e) :"


### PR DESCRIPTION
- Add first name and last name information when the user creates a new account.
<img width="200" alt="image" src="https://user-images.githubusercontent.com/104198121/213866788-874005d2-d6a7-4a80-b52e-fde01efcb12d.png">

- Right display when a group is created.
<img width="199" alt="image" src="https://user-images.githubusercontent.com/104198121/213866873-54405cb8-b9a3-41f5-a5b0-fc78c87ed9b9.png">

- Right display when we create a new consultation
<img width="245" alt="image" src="https://user-images.githubusercontent.com/104198121/213866901-c2112b9e-1e91-4cbf-8a5f-05361f17a545.png">

- Add devise.fr.yml to remove translating message error when a new connection or a new account is created.
<img width="191" alt="image" src="https://user-images.githubusercontent.com/104198121/213866960-7481c55e-dbbb-462c-8c42-5ec6e233add6.png">

<img width="190" alt="image" src="https://user-images.githubusercontent.com/104198121/213866982-74135480-e2e5-47da-9254-4d7176d2e39c.png">

<img width="208" alt="image" src="https://user-images.githubusercontent.com/104198121/213866996-704a87c4-537e-4784-8deb-ab28688e7e00.png">

<img width="195" alt="image" src="https://user-images.githubusercontent.com/104198121/213867027-6ab61550-f45b-4e39-aaf9-f0572a38ca21.png">
